### PR TITLE
Allow Generic Type in NumericHistory

### DIFF
--- a/libraries/NumericHistory/NumericHistory.h
+++ b/libraries/NumericHistory/NumericHistory.h
@@ -2,12 +2,12 @@
 #define NumericHistory_h
 
 /**
- * @brief NumericHistory is a simple, internally manged discarding queue capable of storing up to 256 `uint16_t` numbers.
+ * @brief NumericHistory is a simple, internally manged discarding queue capable of storing up to 256 `TYPE` numbers.
  * Once `LENGTH` amount of entries were stored, the oldest entries will start to be overwritten by new entries in chronological order.
  * 
  * @tparam LENGTH Length of the queue. This defines when to start overwriting old entries with new ones. Smaller values save on memory.
  */
-template <uint8_t LENGTH>
+template <typename TYPE, uint8_t LENGTH>
 class NumericHistory
 {
 public:
@@ -22,26 +22,26 @@ public:
      *
      * @param value The value to be written to the queue.
      */
-    void update(uint16_t value);
+    void update(TYPE value);
 
     /**
      * @brief Returns the full history.
      * 
-     * @return uint16_t* A pointer to the start of the history array in memory.
+     * @return TYPE* A pointer to the start of the history array in memory.
      * The user must be careful not to access memory past the last entry, this can be ensure via checking the length of the history.
      * 
      * @see length
      */
-    uint16_t *get();
+    TYPE *get();
 
     /**
      * @brief Returns a single entry from history.
      * 
      * @param index The index of the entry to be returned, relative to the latest entry. `index=0` will yield the latest entry itself, `index=1` will yield the nextoldest entry and so on.
      * The user must ensure not to query entries past the history's length.
-     * @return uint16_t 
+     * @return TYPE 
      */
-    uint16_t get(uint8_t index);
+    TYPE get(uint8_t index);
 
     /**
      * @brief Returns the length of the history, and thereby the internal array.
@@ -51,7 +51,7 @@ public:
     uint8_t length();
 
 private:
-    uint16_t _history[LENGTH];
+    TYPE _history[LENGTH];
     uint8_t _latestEntry;
 };
 

--- a/libraries/NumericHistory/NumericHistory.tpp
+++ b/libraries/NumericHistory/NumericHistory.tpp
@@ -1,19 +1,19 @@
-template <uint8_t LENGTH>
-NumericHistory<LENGTH>::NumericHistory() : _latestEntry(LENGTH - 1)
+template <typename TYPE, uint8_t LENGTH>
+NumericHistory<TYPE, LENGTH>::NumericHistory() : _latestEntry(LENGTH - 1)
 {
 }
 
-template <uint8_t LENGTH>
-void NumericHistory<LENGTH>::update(uint16_t value)
+template <typename TYPE, uint8_t LENGTH>
+void NumericHistory<TYPE, LENGTH>::update(TYPE value)
 {
     _latestEntry = (_latestEntry + 1) % LENGTH;
     _history[_latestEntry] = value;
 }
 
-template <uint8_t LENGTH>
-uint16_t *NumericHistory<LENGTH>::get()
+template <typename TYPE, uint8_t LENGTH>
+TYPE *NumericHistory<TYPE, LENGTH>::get()
 {
-    static uint16_t out[LENGTH];
+    static TYPE out[LENGTH];
 
     for (int index = 0; index < LENGTH; index++)
     {
@@ -23,14 +23,14 @@ uint16_t *NumericHistory<LENGTH>::get()
     return out;
 }
 
-template <uint8_t LENGTH>
-uint16_t NumericHistory<LENGTH>::get(uint8_t index)
+template <typename TYPE, uint8_t LENGTH>
+TYPE NumericHistory<TYPE, LENGTH>::get(uint8_t index)
 {
     return _history[(_latestEntry + index) % LENGTH];
 }
 
-template <uint8_t LENGTH>
-uint8_t NumericHistory<LENGTH>::length()
+template <typename TYPE, uint8_t LENGTH>
+uint8_t NumericHistory<TYPE, LENGTH>::length()
 {
     return LENGTH;
 }

--- a/main.ino
+++ b/main.ino
@@ -28,8 +28,8 @@ DMX_Master dmxMaster(fixtures[0].channelAmount *fixtureAmount, 2);
 Analyzer MSGEQ7 = Analyzer(6, 7, 0);
 uint16_t frequencyAmplitudes[7]; // stores data from MSGEQ7 chip
 // Auto Gain
-NumericHistory<64> amplitudeHistory = NumericHistory<64>();
-NumericHistory<64> clippingHistory = NumericHistory<64>();
+NumericHistory<uint16_t,64> amplitudeHistory = NumericHistory<uint16_t,64>();
+NumericHistory<uint16_t,64> clippingHistory = NumericHistory<uint16_t,64>();
 const uint8_t targetDutyCycle = 196;          // target value for fixture cross-frequency duty cycle (time-clipped/time-not-clipped in parts of 1023, e.g. 196=19.2%)
 const float amplificationFactorMax = 64;      // maximum allowed amplifaction factor
 const float amplificationFactorMin = 0.015625; // minimal allowed amplification factor


### PR DESCRIPTION
Allows the use of other data types in numeric history.