### PR TITLE
Code Cleanup 1

### DIFF
--- a/software/libraries/DMXFixture/DMXFixture.cpp
+++ b/software/libraries/DMXFixture/DMXFixture.cpp
@@ -1,7 +1,7 @@
 #include <Conceptinetics.h>
 #include "DMXFixture.h"
 
-DMXFixture::DMXFixture(uint8_t startChannel, uint8_t dimmerDefaultValue) : _redChannel(startChannel + localRedChannel - 1), _greenChannel(startChannel + localGreenChannel - 1), _blueChannel(startChannel + localBlueChannel - 1), _whiteChannel(startChannel + localWhiteChannel - 1), _dimmerChannel(startChannel + localDimmerChannel - 1), _strobeChannel(startChannel + localStrobeChannel - 1), _dimmerDefaultValue(dimmerDefaultValue)
+DMXFixture::DMXFixture(uint8_t startChannel, uint8_t dimmerDefaultValue) : _startChannel(startChannel), _dimmerDefaultValue(dimmerDefaultValue)
 {
 }
 
@@ -45,12 +45,12 @@ void DMXFixture::reset()
 
 void DMXFixture::display(DMX_Master &dmxController)
 {
-    dmxController.setChannelValue(_dimmerChannel, _dimmerValue);
-    dmxController.setChannelValue(_redChannel, (uint8_t) (_redValue * ((float)_rgbDimmerValue / 255.0)));
-    dmxController.setChannelValue(_greenChannel,(uint8_t) (_greenValue * ((float)_rgbDimmerValue / 255.0)));
-    dmxController.setChannelValue(_blueChannel, (uint8_t) (_blueValue * ((float)_rgbDimmerValue / 255.0)));
-    dmxController.setChannelValue(_whiteChannel, _whiteValue);
-    dmxController.setChannelValue(_strobeChannel, _strobeValue);
+    dmxController.setChannelValue(_startChannel + localDimmerChannel, _dimmerValue);
+    dmxController.setChannelValue(_startChannel + localRedChannel, (uint8_t) (_redValue * ((float)_rgbDimmerValue / 255.0)));
+    dmxController.setChannelValue(_startChannel + localGreenChannel, (uint8_t) (_greenValue * ((float)_rgbDimmerValue / 255.0)));
+    dmxController.setChannelValue(_startChannel + localBlueChannel, (uint8_t) (_blueValue * ((float)_rgbDimmerValue / 255.0)));
+    dmxController.setChannelValue(_startChannel + localWhiteChannel, _whiteValue);
+    dmxController.setChannelValue(_startChannel + localStrobeChannel, _strobeValue);
 }
 
 

--- a/software/libraries/DMXFixture/DMXFixture.h
+++ b/software/libraries/DMXFixture/DMXFixture.h
@@ -19,12 +19,12 @@
 class DMXFixture
 {
 public:
-    static const uint8_t localDimmerChannel = 1;
-    static const uint8_t localRedChannel = 2;
-    static const uint8_t localGreenChannel = 3;
-    static const uint8_t localBlueChannel = 4;
-    static const uint8_t localWhiteChannel = 5;
-    static const uint8_t localStrobeChannel = 6;
+    static const uint8_t localDimmerChannel = 0;
+    static const uint8_t localRedChannel = 1;
+    static const uint8_t localGreenChannel = 2;
+    static const uint8_t localBlueChannel = 3;
+    static const uint8_t localWhiteChannel = 4;
+    static const uint8_t localStrobeChannel = 5;
     static const uint8_t channelAmount = 6;
 
     /**

--- a/software/libraries/DMXFixture/DMXFixture.h
+++ b/software/libraries/DMXFixture/DMXFixture.h
@@ -90,12 +90,7 @@ public:
     void display(DMX_Master &dmxController);
 
 private:
-    uint8_t _redChannel;
-    uint8_t _greenChannel;
-    uint8_t _blueChannel;
-    uint8_t _whiteChannel;
-    uint8_t _dimmerChannel;
-    uint8_t _strobeChannel;
+    uint8_t _startChannel;
     uint8_t _dimmerDefaultValue;
     uint8_t _dimmerValue;
     uint8_t _rgbDimmerValue;

--- a/software/main.ino
+++ b/software/main.ino
@@ -365,16 +365,25 @@ void setFixtureBrightness(DMXFixture &targetFixture, int *audioAmplitudes, uint3
     uint8_t observedBands = 0;
     for (uint8_t band = 0; band < AUDIO_BANDS; band++)
     {
-        uint8_t bandResponse = ((audioResponse & ((uint32_t)0xF << (band * 4))) >> (band * 4));
+        uint8_t bandResponse = ((audioResponse & ((uint32_t)0xF << (band * 4))) >> (band * 4)); // get response coefficient (is between 0.0 .. 15.0)
         if (bandResponse > 0)
         {
-            brightness += (bandResponse / 16.0) * audioAmplitudes[band];
+            brightness += ((float)bandResponse / 15.0) * audioAmplitudes[band]; // calculate brightness value via scaling the band amplitude by the response coefficient
             observedBands++;
         }
     }
-    targetFixture.setRGBDimmer((uint8_t)(brightness / observedBands));
+    targetFixture.setRGBDimmer((uint8_t)(brightness / observedBands)); // set RGB dimmer to a normalized value
 }
 
+/**
+ * @brief Sets the white value of a single fixture according to the supplied whiteSetting and strobeEnabled.
+ *
+ * @param targetFixture The fixture object to be acted upon.
+ * @param fixtureId The id of the currently targeted fixture. Used to allow for physical-location-based whiteSettings.
+ * @param strobeEnabled Whether the strobe should be enabled.
+ * @param strobeFrequency The frequency of the strobe, between 1 and 100 (inclusive)
+ * @param whiteSetting Which whiteSetting to follow. This specifies which fixtures should have their white channels set to a non-zero value.
+ */
 void setFixtureWhite(DMXFixture &targetFixture, uint8_t fixtureId, bool strobeEnabled, uint8_t strobeFrequency, uint8_t whiteSetting)
 {
     // reset white value to 0

--- a/software/main.ino
+++ b/software/main.ino
@@ -7,17 +7,17 @@
 // ================================================================
 //                           CONSTANTS
 // ================================================================
-const uint8_t BRIGHTNESS_CAP = 217; // 85% max brightness to increase LED lifetime
-const uint16_t PROFILE_CYCLE_PERIOD_MS = 5000;
-const uint8_t FRAME_PERIOD_MS = 66;
-const uint8_t SAMPLES_PER_FRAME = 1;
-const uint8_t SAMPLE_DELAY_MS = 1;
-const uint8_t AUDIO_BANDS = 7;
-const uint16_t AUDIO_BAND_MAX = 1023;
-const uint8_t DMX_CHANNEL_MAX = 255;
-const float TARGET_CLIPPING = 196.0;    // target value for fixture cross-frequency duty cycle (time-clipped/time-not-clipped in parts of 1023, e.g. 196=19.2%)
-const float AMP_FACTOR_MAX = 64.0;      // maximum allowed amplifaction factor
-const float AMP_FACTOR_MIN = 0.0078125; // minimal allowed amplification factor (1/128)
+const uint8_t BRIGHTNESS_CAP = 217;            // 85% max brightness to increase LED lifetime
+const uint16_t PROFILE_CYCLE_PERIOD_MS = 5000; // amount of milliseconds until the profile assignments between lamps is rotated.
+const uint8_t FRAME_PERIOD_MS = 66;            // target value for the duration of a single frame. If the frame takes less then this, the processor will wait before moving on to the next frame.
+const uint8_t SAMPLES_PER_FRAME = 1;           // amount of consecutive samples to take within one frame. Higher values pratically act as a low-pass filter
+const uint8_t SAMPLE_DELAY_MS = 1;             // time delay between consecutive samples
+const uint8_t AUDIO_BANDS = 7;                 // amount of audio bands provided by the FFT chip. The MSGEQ7 provides 7 bands.
+const uint16_t AUDIO_BAND_MAX = 1023;          // maximum value to expect from the analoge audio signal 1023 = 10-bit ADC
+const uint8_t DMX_CHANNEL_MAX = 255;           // maximum value allowed on a DMX channel. The DMX spec defines this as 255.
+const float TARGET_CLIPPING = 196.0;           // target value for fixture cross-frequency duty cycle (time-clipped/time-not-clipped in parts of 1023, e.g. 196=19.2%)
+const float AMP_FACTOR_MAX = 64.0;             // maximum allowed amplifaction factor
+const float AMP_FACTOR_MIN = 0.0078125;        // minimal allowed amplification factor (1/128)
 
 // ================================================================
 //                         CONFIGURATION
@@ -64,7 +64,7 @@ void setup()
     // Start LCD
     userInterface.setQuickSettingFunction(toggleStrobe);
     userInterface.initializeDisplay(0x27);
-    userInterface.print(F("   Phosphoros   "), F(" ver 2023-06-28 "));
+    userInterface.print(F("   Phosphoros   "), F(" ver 2023-06-29 "));
     delay(1000);
 
     // Start FFT

--- a/software/main.ino
+++ b/software/main.ino
@@ -64,7 +64,7 @@ void setup()
     // Start LCD
     userInterface.setQuickSettingFunction(toggleStrobe);
     userInterface.initializeDisplay(0x27);
-    userInterface.print(F("    arduDMX     "), F(" ver 2023-06-28 "));
+    userInterface.print(F("   Phosphoros   "), F(" ver 2023-06-28 "));
     delay(1000);
 
     // Start FFT

--- a/software/main.ino
+++ b/software/main.ino
@@ -4,35 +4,32 @@
 #include <LatchedButton.h>
 #include <UserInterface.h>
 
-// ===== GLOBAL SETTINGS ======
-// Light Fixture Data
-const uint8_t maxBrightness = 217; // 85% max brightness to increase LED lifetime
-DMXFixture fixtures[] = {DMXFixture(1, maxBrightness), DMXFixture(7, maxBrightness), DMXFixture(13, maxBrightness), DMXFixture(19, maxBrightness)};                                       // configured fixtures and their start channels. The maximum amount of supported fixtures is 16.
-const FixtureProfile rgbColorSet[] = {FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x0000FF, 0x0039000), FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x00FF00, 0xFF00000)}; // profiles that fixtures can assume. Each profile consists of a hex code for color and a hex code for frequencies the fixture should respond to.
-const FixtureProfile cmyColorSet[] = {FixtureProfile(0x800080, 0x00000FF), FixtureProfile(0xA06000, 0xFF00000), FixtureProfile(0x800080, 0x00000FF), FixtureProfile(0x008080, 0x0039000)};
-const FixtureProfile coldColorSet[] = {FixtureProfile(0x4B00B4, 0x00000FF), FixtureProfile(0x0000FF, 0xFF00000), FixtureProfile(0x4B00B4, 0x00000FF), FixtureProfile(0x464673, 0x0039000)};
-const FixtureProfile uwuColorSet[] = {FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x71008E, 0xFF00000), FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0xAA0055, 0x0039000)};
-const uint8_t targetFrameTimeMs = 66;
-// MSGEQ7 Signal Data
-const uint8_t samplesPerRun = 1; // number of consecutive samples to take whenever the audio is sampled (these are then averaged). Higher values inhibit random noise spikes, but average out details.
-const uint8_t delayBetweenSamples = 1; // time in ms to wait between samples in a consecutive sample run. High values will decrease temporal resolution drastically.
-//  =============================
+// ================================================================
+//                           CONSTANTS
+// ================================================================
+const uint8_t BRIGHTNESS_CAP = 217; // 85% max brightness to increase LED lifetime
+const uint16_t PROFILE_CYCLE_PERIOD_MS = 5000;
+const uint8_t FRAME_PERIOD_MS = 66;
+const uint8_t SAMPLES_PER_FRAME = 1;
+const uint8_t SAMPLE_DELAY_MS = 1;
+const uint8_t AUDIO_BANDS = 7;
+const uint16_t AUDIO_BAND_MAX = 1023;
+const uint8_t DMX_CHANNEL_MAX = 255;
+const float TARGET_CLIPPING = 196.0;    // target value for fixture cross-frequency duty cycle (time-clipped/time-not-clipped in parts of 1023, e.g. 196=19.2%)
+const float AMP_FACTOR_MAX = 64.0;      // maximum allowed amplifaction factor
+const float AMP_FACTOR_MIN = 0.0078125; // minimal allowed amplification factor (1/128)
 
-// ===== GLOBAL VARIABLES ======
-// Fixture Management
-const uint8_t fixtureAmount = sizeof(fixtures) / sizeof(DMXFixture);
-const uint8_t profileAmount = sizeof(rgbColorSet) / sizeof(FixtureProfile);
-const FixtureProfile *const profiles[] = {rgbColorSet, cmyColorSet, coldColorSet, uwuColorSet};
-// Automatic Profile Cycling
-uint32_t lastPermutatedAtMs;
-uint64_t cachedPermutationCode;
-const uint16_t permutationCycleLengthMs = 5000;
-// DMX Hardware
-DMX_Master dmxMaster(fixtures[0].channelAmount *fixtureAmount, 2);
-// FFT Hardware
-Analyzer MSGEQ7(7, 4, 0);
-uint16_t frequencyAmplitudes[7]; // stores data from MSGEQ7 chip
-// User Interface Hardware
+// ================================================================
+//                         CONFIGURATION
+// ================================================================
+DMXFixture FIXTURES[] = {DMXFixture(1, BRIGHTNESS_CAP), DMXFixture(7, BRIGHTNESS_CAP), DMXFixture(13, BRIGHTNESS_CAP), DMXFixture(19, BRIGHTNESS_CAP)};                                      // configured fixtures and their start channels. The maximum amount of supported fixtures is 16.
+const FixtureProfile RGB_COLOR_SET[] = {FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x0000FF, 0x0039000), FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x00FF00, 0xFF00000)}; // profiles that fixtures can assume. Each profile consists of a hex code for color and a hex code for frequencies the fixture should respond to.
+const FixtureProfile CMY_COLOR_SET[] = {FixtureProfile(0x800080, 0x00000FF), FixtureProfile(0xA06000, 0xFF00000), FixtureProfile(0x800080, 0x00000FF), FixtureProfile(0x008080, 0x0039000)};
+const FixtureProfile COLD_COLOR_SET[] = {FixtureProfile(0x4B00B4, 0x00000FF), FixtureProfile(0x0000FF, 0xFF00000), FixtureProfile(0x4B00B4, 0x00000FF), FixtureProfile(0x464673, 0x0039000)};
+const FixtureProfile UWU_COLOR_SET[] = {FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0x71008E, 0xFF00000), FixtureProfile(0xFF0000, 0x00000FF), FixtureProfile(0xAA0055, 0x0039000)};
+const uint8_t FIXTURE_AMOUNT = sizeof(FIXTURES) / sizeof(DMXFixture);
+const uint8_t PROFILE_AMOUNT = sizeof(RGB_COLOR_SET) / sizeof(FixtureProfile);
+const FixtureProfile *const PROFILE_GROUPS[] = {RGB_COLOR_SET, CMY_COLOR_SET, COLD_COLOR_SET, UWU_COLOR_SET};
 uint8_t whiteLightSetting = 0;
 uint8_t gainModeSetting = 0;
 uint8_t strobeFrequencySetting = 100;
@@ -43,26 +40,31 @@ void toggleStrobe(bool alternateAction)
 {
     strobeEnabled ^= 1;
 }
-SettingsPage pages[] = {SettingsPageFactory("Lights", &whiteLightSetting).setLinkedVariableLimits(0, 4).setDisplayAlias("  OFF  BARTABLE  ALL").finalize(), SettingsPageFactory("Strobe", &strobeFrequencySetting).setLinkedVariableLimits(0, 101).setLinkedVariableUnits('%').finalize(), SettingsPageFactory("Gain", &gainModeSetting).setLinkedVariableLimits(0, 3).setDisplayAlias(" AUTO  LOW HIGH").enableChangePreviews().finalize(), SettingsPageFactory("Colors", &colorSetSetting).setLinkedVariableLimits(0, 4).setDisplayAlias("  RGB  CMY COLD  uwu").enableChangePreviews().finalize(), SettingsPageFactory("Frame ms", &msPerFrameMonitor).makeMonitor().finalize()};
-SettingsDisplay<5> userInterface(pages);
-LatchedButton<8> plusButton(3, 1000/targetFrameTimeMs);
-LatchedButton<8> selectButton(5, 1000/targetFrameTimeMs);
-LatchedButton<8> minusButton(6, 1000/targetFrameTimeMs);
-LatchedButton<8> functionButton(9, 1000/targetFrameTimeMs);
-// Auto Gain
-const float targetCrossBandClipping = 196.0;           // target value for fixture cross-frequency duty cycle (time-clipped/time-not-clipped in parts of 1023, e.g. 196=19.2%)
-const float amplificationFactorMax = 64.0;       // maximum allowed amplifaction factor
-const float amplificationFactorMin = 1e-6; // minimal allowed amplification factor (1/1024)
-float amplificationFactor = 12.0;             // amplification for signals considered non-noise (ones that should result in a non-zero light response), managed automatically
-uint16_t noiseLevel = 0;                      // lower bound for noise, determined automatically at startup
-// =============================
+const SettingsPage SETTINGS_PAGES[] = {SettingsPageFactory("Lights", &whiteLightSetting).setLinkedVariableLimits(0, 4).setDisplayAlias("  OFF  BARTABLE  ALL").finalize(), SettingsPageFactory("Strobe", &strobeFrequencySetting).setLinkedVariableLimits(0, 101).setLinkedVariableUnits('%').finalize(), SettingsPageFactory("Gain", &gainModeSetting).setLinkedVariableLimits(0, 3).setDisplayAlias(" AUTO  LOW HIGH").enableChangePreviews().finalize(), SettingsPageFactory("Colors", &colorSetSetting).setLinkedVariableLimits(0, 4).setDisplayAlias("  RGB  CMY COLD  uwu").enableChangePreviews().finalize(), SettingsPageFactory("Frame ms", &msPerFrameMonitor).makeMonitor().finalize()};
 
+// ================================================================
+//                           SUBSYSTEMS
+// ================================================================
+DMX_Master dmxMaster(FIXTURES[0].channelAmount *FIXTURE_AMOUNT, 2);
+Analyzer MSGEQ7(7, 4, 0);
+uint16_t bandAmplitudes[AUDIO_BANDS];
+float amplificationFactor = 12.0; // amplification for signals considered non-noise (ones that should result in a non-zero light response), managed automatically
+uint16_t noiseLevel = 0;          // lower bound for noise, determined automatically at startup
+SettingsDisplay<5> userInterface(SETTINGS_PAGES);
+LatchedButton<8> plusButton(3, 1000 / FRAME_PERIOD_MS);
+LatchedButton<8> selectButton(5, 1000 / FRAME_PERIOD_MS);
+LatchedButton<8> minusButton(6, 1000 / FRAME_PERIOD_MS);
+LatchedButton<8> functionButton(9, 1000 / FRAME_PERIOD_MS);
+
+// ================================================================
+//                       STARTUP SEQUENCE
+// ================================================================
 void setup()
 {
     // Start LCD
     userInterface.setQuickSettingFunction(toggleStrobe);
     userInterface.initializeDisplay(0x27);
-    userInterface.print(F("    arduDMX     "), F(" ver 2023-06-20 "));
+    userInterface.print(F("    arduDMX     "), F(" ver 2023-06-28 "));
     delay(1000);
 
     // Start FFT
@@ -75,52 +77,51 @@ void setup()
     dmxMaster.enable();
 
     // Initialize Light Fixtures
-    for (uint8_t fixtureId = 0; fixtureId < fixtureAmount; fixtureId++)
+    for (uint8_t fixtureId = 0; fixtureId < FIXTURE_AMOUNT; fixtureId++)
     {
-        fixtures[fixtureId].reset(); // reset to default values
+        FIXTURES[fixtureId].reset(); // reset to default values
     }
-
-    // Generate Profile Permutation Code
-    cachedPermutationCode = 0xFEDCBA9876543210ul & ((0x1ul << (4 * profileAmount)) - 0x1); // ul postfix required to format literal as unsigned long
-    lastPermutatedAtMs = 0;
 
     // Analyze Noise Levels (THERE MUST NOT BE AUDIO ON THE JACK FOR THIS TO WORK)
     userInterface.print(F("    Probing     "), F("     Noise...    "));
     int noiseData[] = {0, 0, 0, 0, 0, 0, 0};
     sampleMSGEQ7(32, 1, noiseData);
-    noiseLevel = getAverage(noiseData, 7, 12); // average over all frequencies and add some extra buffer
+    noiseLevel = getAverage(noiseData, AUDIO_BANDS, 12); // average over all frequencies and add some extra buffer
 
     userInterface.print(F("     Setup      "), F("   Complete!    "));
     delay(500); // wait a bit for everything to stabalize
     userInterface.showPages();
 }
 
+// ================================================================
+//                           MAIN LOOP
+// ================================================================
 void loop()
 {
     // Store frame start time
     uint32_t frameStartTime = millis();
 
     // Get FFT data from MSGEQ7 chip
-    sampleMSGEQ7(samplesPerRun, delayBetweenSamples, frequencyAmplitudes);
+    sampleMSGEQ7(SAMPLES_PER_FRAME, SAMPLE_DELAY_MS, bandAmplitudes);
 
     // Transform audio signal levels to light signal levels and apply amplification
-    uint16_t signalMean = calculateSignalMean(frequencyAmplitudes, noiseLevel);
-    uint16_t crossBandClipping = mapAudioAmplitudeToLightLevel(frequencyAmplitudes, signalMean + noiseLevel, amplificationFactor);
+    uint16_t signalMean = calculateSignalMean(bandAmplitudes, noiseLevel);
+    uint16_t crossBandClipping = mapAudioAmplitudeToLightLevel(bandAmplitudes, signalMean + noiseLevel, amplificationFactor);
     updateAmplificationFactor(amplificationFactor, crossBandClipping);
 
     // Select and Cycle Fixture Profiles
-    FixtureProfile permutatedProfiles[fixtureAmount];
-    permutateProfiles(generatePermutationCode(cachedPermutationCode, permutationCycleLengthMs), profiles[colorSetSetting], permutatedProfiles, fixtureAmount);
+    FixtureProfile permutatedProfiles[FIXTURE_AMOUNT];
+    permutateProfiles(generatePermutationCode(), permutatedProfiles);
 
     // Manage Fixtures
-    for (uint8_t fixtureId = 0; fixtureId < fixtureAmount; fixtureId++)
+    for (uint8_t fixtureId = 0; fixtureId < FIXTURE_AMOUNT; fixtureId++)
     {
-        setFixtureColor(fixtures[fixtureId], frequencyAmplitudes, permutatedProfiles[fixtureId].getHexColor()); // set color data
-        setFixtureBrightness(fixtures[fixtureId], frequencyAmplitudes, permutatedProfiles[fixtureId].getHexFrequency()); // set brightness data
-        setFixtureWhite(fixtures[fixtureId], fixtureId, strobeEnabled, strobeFrequencySetting, whiteLightSetting);
+        setFixtureColor(FIXTURES[fixtureId], bandAmplitudes, permutatedProfiles[fixtureId].getHexColor());          // set color data
+        setFixtureBrightness(FIXTURES[fixtureId], bandAmplitudes, permutatedProfiles[fixtureId].getHexFrequency()); // set brightness data
+        setFixtureWhite(FIXTURES[fixtureId], fixtureId, strobeEnabled, strobeFrequencySetting, whiteLightSetting);
 
         // send data to fixtures
-        fixtures[fixtureId].display(dmxMaster);
+        FIXTURES[fixtureId].display(dmxMaster);
     }
 
     // Send Button inputs to UI and update UI accordingly
@@ -149,22 +150,26 @@ void loop()
 
     // Wait until frame time is over
     msPerFrameMonitor = (uint8_t)(millis() - frameStartTime);
-    int16_t remainingFrameTimeMs = targetFrameTimeMs - msPerFrameMonitor;
+    int16_t remainingFrameTimeMs = FRAME_PERIOD_MS - msPerFrameMonitor;
     delay(max(remainingFrameTimeMs, 0));
 }
 
+// ================================================================
+//                       HELPER FUNCTIONS
+// ================================================================
+
 /**
  * @brief Calculates the temporal mean value of an audio signal, with the noise level removed.
- * 
+ *
  * @param bandAmplitudes The amplitudes of the 7 frequency bands provided by the MSGEQ7 chip.
  * @param noiseLevel A base noise level to be subtracted from the supplied bandAmplitudes before processing.
  * @return uint16_t The temporal mean of the cross-band signal amplitude.
  */
 uint16_t calculateSignalMean(uint16_t *bandAmplitudes, uint16_t noiseLevel)
 {
-    static NumericHistory<uint16_t,32> amplitudeHistory = NumericHistory<uint16_t,32>();
+    static NumericHistory<uint16_t, 32> amplitudeHistory = NumericHistory<uint16_t, 32>();
 
-    int32_t crossBandSignal = getAverage(bandAmplitudes, 7, 0) - noiseLevel;
+    int32_t crossBandSignal = getAverage(bandAmplitudes, AUDIO_BANDS, 0) - noiseLevel;
     amplitudeHistory.update(max(crossBandSignal, 0));
 
     return getAverage(amplitudeHistory.get(), amplitudeHistory.length(), 0);
@@ -176,7 +181,7 @@ uint16_t calculateSignalMean(uint16_t *bandAmplitudes, uint16_t noiseLevel)
  * @param bandAmplitudes An array of 12-bit band amplitudes provided by the MSGEQ7 chip. This array will be modified in-place.
  * @param bandAverage The average absolute value to be expected across all bands. All band amplitudes which are less than this value will be set to `0` in the output.
  * @param amplificationFactor The amplification factor to be applied to the signal.
- * 
+ *
  * @return [0..1023] The average of the cross-band clipping. This is calculated as follows:
  * Each band which is detected to be clipping (i.e. has a value of `1023` or larger after the amplification factor was applied) is assigned the value `1023`,
  * each band which is not clipping is assigned a value of `0` in a temporary array. The average of this array is what is returned.
@@ -184,42 +189,41 @@ uint16_t calculateSignalMean(uint16_t *bandAmplitudes, uint16_t noiseLevel)
 uint16_t mapAudioAmplitudeToLightLevel(uint16_t *bandAmplitudes, uint16_t bandAverage, float &amplificationFactor)
 {
     uint16_t bandClippings[] = {0, 0, 0, 0, 0, 0, 0};
-    for (uint8_t band = 0; band < 7; band++)
+    for (uint8_t band = 0; band < AUDIO_BANDS; band++)
     {
-        int32_t halfSignalWidth = (int32_t) bandAmplitudes[band] - bandAverage; // calculate average absolute value of this band
+        int32_t halfSignalWidth = (int32_t)bandAmplitudes[band] - bandAverage;    // calculate average absolute value of this band
         uint16_t signalAmplified = max(halfSignalWidth, 0) * amplificationFactor; // amplify parts of the signal that are larger than the supplied bandAverage
-        if (signalAmplified >= 1023)
+        if (signalAmplified >= AUDIO_BAND_MAX)
         {
-            bandClippings[band] = 1023; // remember the signal clipped
+            bandClippings[band] = AUDIO_BAND_MAX; // remember the signal clipped
         }
-      
-        signalAmplified = signalAmplified >> 2; // divide by 4 via shifting by 2
-        bandAmplitudes[band] = (int)min(signalAmplified, 255); // scale to [0..255] for use in light fixtures
+
+        signalAmplified = signalAmplified >> ((AUDIO_BAND_MAX + 1) / (2 * (DMX_CHANNEL_MAX + 1))); // scale [0,AUDIO_BAND_MAX] signal to be within [0,DMX_CHANNEL_MAX], here we use that x/2 == x>>1
+        bandAmplitudes[band] = (int)min(signalAmplified, DMX_CHANNEL_MAX);                         // scale to [0..255] for use in light fixtures
     }
 
-    return getAverage(bandClippings, 7, 0); // return average cross-band clipping
+    return getAverage(bandClippings, AUDIO_BANDS, 0); // return average cross-band clipping
 }
 
 /**
  * @brief Updates the amplification factor according to the `gainModeSetting` (global variable).
- * 
+ *
  * @param amplificationFactor The amplification factor to be updated.
  * If `gainModeSetting` is `1`, it will always be set to `0.5`.
  * If `gainModeSetting` is `2`, it will always be set to `48`.
  * If `gainModeSetting` is `0`, it will be dynamically calculated from the latest clipping history.
  * @param crossBandClipping The latest cross-band clipping average,
  * aka the average created when every band that has clipped is assigned 1023, and every band that has not clipped is assigned 0.
- * @param targetCrossBandClipping The desired target value for `crossBandClipping`.
  */
 void updateAmplificationFactor(float &amplificationFactor, uint16_t crossBandClipping)
 {
-    static NumericHistory<uint16_t,32> clippingHistory = NumericHistory<uint16_t,32>();
+    static NumericHistory<uint16_t, 32> clippingHistory = NumericHistory<uint16_t, 32>();
 
     clippingHistory.update(crossBandClipping);
     if (gainModeSetting == 0)
     {
-        float clippingDeviation = targetCrossBandClipping / ((float) getAverage(clippingHistory.get(), clippingHistory.length(), 0)); // target ('wanted') value for the cross-band clipping is 196.0 = 19.1%
-        amplificationFactor = constrain(clippingDeviation, amplificationFactorMin, amplificationFactorMax); // limit the amplification factor to be within this range
+        float clippingDeviation = TARGET_CLIPPING / ((float)getAverage(clippingHistory.get(), clippingHistory.length(), 0)); // target ('wanted') value for the cross-band clipping is 196.0 = 19.1%
+        amplificationFactor = constrain(clippingDeviation, AMP_FACTOR_MIN, AMP_FACTOR_MAX);                                  // limit the amplification factor to be within this range
     }
     else if (gainModeSetting == 1)
     {
@@ -248,7 +252,7 @@ uint16_t getAverage(int *array, uint16_t elements, uint16_t buffer)
     }
 
     sum = buffer + (sum / elements);
-    return min(sum, 1023);
+    return min(sum, AUDIO_BAND_MAX);
 }
 
 /**
@@ -266,7 +270,7 @@ void sampleMSGEQ7(int8_t sampleAmount, uint16_t sampleDelay, int *targetArray)
         uint16_t sampleAmplitudes[] = {0, 0, 0, 0, 0, 0, 0};
         MSGEQ7.ReadFreq(sampleAmplitudes); // store amplitudes of frequency bands into array
                                            // Frequency(Hz):        63  160  400  1K  2.5K  6.25K  16K
-                                           // frequencyAmplitudes[]: 0    1    2   3     4      5    6
+                                           // bandAmplitudes[]: 0    1    2   3     4      5    6
 
         averageAmplitudes[0] += sampleAmplitudes[0]; // sum up samples
         averageAmplitudes[1] += sampleAmplitudes[1];
@@ -294,22 +298,20 @@ void sampleMSGEQ7(int8_t sampleAmount, uint16_t sampleDelay, int *targetArray)
  * @param permutation The permutation to be used when assembling `permutatedProfiles` from `constProfiles`. The permutation is encoded as a 64-bit number,
  * consisting of 16 consequtive source addresses. The target address is deducted from the position of the source address within the 64-bit instruction.
  * E.g. `0x01234567` would load the profile in slot 7 into the fixture in slot 0, the profile in slot 6 into the fixture in slot 1 and so on.
- * @param constProfiles An array of FixtureProfiles used to read FixtureProfiles from. This should be constant.
  * @param permutatedProfiles An array of FixtureProfiles that will have the permutation stored into it.
- * @param fixtureAmount The amount of fixtures.
  */
-void permutateProfiles(uint64_t permutation, FixtureProfile *constProfiles, FixtureProfile *permutatedProfiles, uint16_t fixtureAmount)
+void permutateProfiles(uint64_t permutation, FixtureProfile *permutatedProfiles)
 {
     // store shuffled profiles into arrays for the fixtures to read from.
     // Note that these arrays only require a length of fixtureAmount, as any additional profiles will not be displayed on a fixture anyways.
-    for (uint8_t profileSlot = 0; profileSlot < fixtureAmount; profileSlot++)
+    for (uint8_t profileSlot = 0; profileSlot < FIXTURE_AMOUNT; profileSlot++)
     {
         // extract lowest instruction and shift remaining instructions
         uint8_t profileSource = (permutation & 0xF);
         permutation = (permutation >> 4);
 
         // store to shuffled profile
-        permutatedProfiles[profileSlot] = constProfiles[profileSource];
+        permutatedProfiles[profileSlot] = PROFILE_GROUPS[colorSetSetting][profileSource];
     }
 }
 
@@ -318,22 +320,23 @@ void permutateProfiles(uint64_t permutation, FixtureProfile *constProfiles, Fixt
  * Once the cycle length has been exceeded, the last permutation is cycled by one step,
  * otherwise the method returns the provided permutation without modifications.
  * This cycling is done to equally utilize LEDs over all fixture, preventing "burn in".
- * 
- * @param previousPermutationCode Reference to the previous permutation code.
- * @param cycleLengthMs How long once permutation should last until shuffled.
+ *
  * @return uint64_t The (modified) permutation.
  */
-uint64_t generatePermutationCode(uint64_t &previousPermutationCode, uint16_t cycleLengthMs)
+uint64_t generatePermutationCode()
 {
+    static uint32_t permutationTimestamp = 0;
+    static uint64_t permutationCode = 0xFEDCBA9876543210ul & ((0x1ul << (4 * PROFILE_AMOUNT)) - 0x1);
+
     // if last permutation shift wasn't too long, return last permutation
     uint32_t timeNow = millis();
-    if (timeNow - lastPermutatedAtMs < cycleLengthMs)
-        return previousPermutationCode;
+    if (timeNow - permutationTimestamp < PROFILE_CYCLE_PERIOD_MS)
+        return permutationCode;
 
     // shift last permutation
-    previousPermutationCode = (previousPermutationCode >> 4) + ((previousPermutationCode & ((0x1ul << 4) - 0x1)) << ((4 * profileAmount) - 4));
-    lastPermutatedAtMs = timeNow;
-    return previousPermutationCode;
+    permutationCode = (permutationCode >> 4) + ((permutationCode & ((0x1ul << 4) - 0x1)) << ((4 * PROFILE_AMOUNT) - 4));
+    permutationTimestamp = timeNow;
+    return permutationCode;
 }
 
 /**
@@ -360,7 +363,7 @@ void setFixtureBrightness(DMXFixture &targetFixture, int *audioAmplitudes, uint3
 {
     uint8_t brightness = 0;
     uint8_t observedBands = 0;
-    for (uint8_t band = 0; band < 7; band++)
+    for (uint8_t band = 0; band < AUDIO_BANDS; band++)
     {
         uint8_t bandResponse = ((audioResponse & ((uint32_t)0xF << (band * 4))) >> (band * 4));
         if (bandResponse > 0)
@@ -382,8 +385,8 @@ void setFixtureWhite(DMXFixture &targetFixture, uint8_t fixtureId, bool strobeEn
 
     if (strobeEnabled) // if strobe is on, enable white on all fixtures
     {
-        targetFixture.setWhite(255);
-        targetFixture.setStrobe(strobeFrequency * (255/100));
+        targetFixture.setWhite(DMX_CHANNEL_MAX);
+        targetFixture.setStrobe(strobeFrequency * (DMX_CHANNEL_MAX / 100));
     }
     else if (whiteSetting) // if strobe is off, white is only enabled on fixtures depending on white setting. If whiteSetting == 0, none of these special rules apply
     {
@@ -393,7 +396,7 @@ void setFixtureWhite(DMXFixture &targetFixture, uint8_t fixtureId, bool strobeEn
         }
         else if (whiteSetting == 3)
         {
-            targetFixture.setWhite(255); // full bright mode for all lights on
+            targetFixture.setWhite(DMX_CHANNEL_MAX); // full bright mode for all lights on
         }
     }
 }


### PR DESCRIPTION
First major code cleanup.
This PR cleans up the constants in `main.ino` and simplifies the `DMXFixture` class to reduce memory usage.
Global constants are no longer supplied to functions as parameters but are read directly and highlighted using `CAPITAL_SNAKE_CASE`.

Also renames the Software to the project's final name **Phosphoros** (greek for 'the bringer of light'). This naming change will be slowely propegated through all branding before release of version 1.0.